### PR TITLE
qmi-framweork: expose qmi headers to clients

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,5 +3,5 @@
 
 # Makefile.am - Automake script for QMI Framework
 ACLOCAL_AMFLAGS = -I m4
-
+pkginclude_HEADERS = include/*.h
 SUBDIRS = common qencdec qcci qcsi tests


### PR DESCRIPTION
Add instruction in Makefile to install qmi headers in include directory.