### PR TITLE
qmi-framework: Fix include paths and header installation behaviour

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Makefile.am - Automake script for QMI Framework
+AM_CPPFLAGS = -I$(top_srcdir)/include
 ACLOCAL_AMFLAGS = -I m4
-pkginclude_HEADERS = include/*.h
+pkginclude_HEADERS = \
+                include/common_v01.h \
+                include/qcsi.h \
+                include/qcsi_target_ext.h \
+                include/qmi_cci_target_ext.h \
+                include/qmi_client.h \
+                include/qmi_idl_lib.h \
+                include/qmi_idl_lib_internal.h
 SUBDIRS = common qencdec qcci qcsi tests

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -10,7 +10,7 @@ AM_CFLAGS = -Wundef \
         -fpic
 
 AM_CPPFLAGS = \
-        -I../include
+        -I$(top_srcdir)/include
 
 h_sources = qmi_common.h
 
@@ -18,7 +18,7 @@ if GNU_CC
 requiredlibs = -lpthread
 endif
 library_includedir = $(pkgincludedir)
-library_include_HEADERS = $(h_sources)
+noinst_HEADERS = $(h_sources)
 
 c_sources = common_v01.c
 

--- a/qcci/Makefile.am
+++ b/qcci/Makefile.am
@@ -12,8 +12,8 @@ AM_CFLAGS = -Wundef \
         -DQMI_FW_SYSLOG
 
 AM_CPPFLAGS = \
-        -I../include \
-        -I../common/ \
+        -I$(top_srcdir)/include \
+        -I$(top_srcdir)/common/ \
         -I$(top_builddir) \
         $(QMI_CFLAGS) \
         $(QMIFV_CFLAGS)
@@ -36,7 +36,7 @@ requiredlibs += -lpthread
 endif
 
 library_includedir = $(pkgincludedir)
-library_include_HEADERS = $(h_sources)
+noinst_HEADERS = $(h_sources)
 
 c_sources = qcci.c \
         qcci_os.c \

--- a/qcsi/Makefile.am
+++ b/qcsi/Makefile.am
@@ -12,8 +12,8 @@ AM_CFLAGS = -Wundef \
 	-DQMI_FW_SYSLOG
 
 AM_CPPFLAGS = \
-        -I../include \
-        -I../common/ \
+        -I$(top_srcdir)/include \
+        -I$(top_srcdir)/common/ \
         -I$(top_builddir) \
         $(QMI_CFLAGS) \
         $(QMIFV_CFLAGS)
@@ -36,7 +36,7 @@ requiredlibs += -lpthread
 endif
 
 library_includedir = $(pkgincludedir)
-library_include_HEADERS = $(h_sources)
+noinst_HEADERS = $(h_sources)
 
 c_sources = qcsi_common.c \
         qcsi_os.c \

--- a/qencdec/Makefile.am
+++ b/qencdec/Makefile.am
@@ -10,7 +10,7 @@ AM_CFLAGS = -Wundef \
         -fpic
 
 AM_CPPFLAGS = \
-        -I../include
+        -I$(top_srcdir)/include
 
 h_sources = qmi_idl_lib_target.h
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -10,7 +10,7 @@ AM_CFLAGS = -Wundef \
         -fpic \
         $(QMI_CFLAGS)
 
-AM_CPPFLAGS = -I../include -I../qcsi -I../common
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/qcsi -I$(top_srcdir)/common
 
 requiredlibs = ../qencdec/libqencdec.la ../common/libqmi_common.la ../qcci/libqcci.la ../qcsi/libqcsi.la
 


### PR DESCRIPTION
- Replace relative include paths with absolute references to ensure compatibility with out-of-tree builds.

- Removed wildcard usage in pkginclude_HEADERS and listed explicit header files to avoid automake errors.