### PR TITLE
ci: Add QC preflight checks workflow

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -1,0 +1,24 @@
+name: QC Preflight Checks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  preflight:
+    name: Run QC Preflight Checks
+    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@v2
+    with:
+      enable-semgrep-scan: true
+      enable-dependency-review: true
+      enable-repolinter-check: true
+      enable-copyright-license-check: true
+      enable-commit-email-check: true
+      enable-commit-msg-check: false
+      enable-armor-checkers: false
+
+    permissions:
+      contents: read
+      security-events: write


### PR DESCRIPTION
Adds the Qualcomm preflight checks workflow from qcom-actions, enabling semgrep scans, dependency review, copyright/license checks, and commit email validation on PRs and pushes to main.