### PR TITLE
ci: Replace pull_request_target with pull_request in PR workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,6 @@
 name: Prevent pull request to main
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened


### PR DESCRIPTION
pull_request_target grants write access from fork context which fails the QC preflight security check. Use pull_request instead.