### PR TITLE
ci: Sync development with main — pick up OSSOP workflow fixes

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,6 @@
 name: Prevent pull request to main
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened

--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -1,0 +1,24 @@
+name: QC Preflight Checks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  preflight:
+    name: Run QC Preflight Checks
+    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@v2
+    with:
+      enable-semgrep-scan: true
+      enable-dependency-review: true
+      enable-repolinter-check: true
+      enable-copyright-license-check: true
+      enable-commit-email-check: true
+      enable-commit-msg-check: false
+      enable-armor-checkers: false
+
+    permissions:
+      contents: read
+      security-events: write


### PR DESCRIPTION
`development` and `main` diverged when two workflow changes were merged
directly into `main` as part of an OSSOP compliance ticket during the
quic → qualcomm org migration, bypassing the usual development → main
flow. This PR brings `development` back in sync by cherry-picking the
same two commits.

Changes: 
- ci: Add QC preflight checks workflow (`qcom-preflight-checks.yml`)
Runs semgrep, dependency review, repolinter, copyright/license, and
commit-email checks via qualcomm/qcom-reusable-workflows on PRs and
pushes to main. This is the OSSOP-required compliance gate; syncing
it into development means PRs opened against development also get
scanned, not just PRs against main.
- ci: Replace pull_request_target with pull_request in pull-request.yml
Security hardening — pull_request_target runs with base-repo secrets/
write access even for fork PRs; pull_request runs in the fork's own
limited context instead.

No source or build files changed — .github/workflows/ only. After this
merges, development and main will be identical again, restoring the
normal development → main contribution flow.