### PR TITLE
build: Fix pkg-config Cflags to match header install path

### DIFF
--- a/qmi-framework.pc.in
+++ b/qmi-framework.pc.in
@@ -8,4 +8,4 @@ Description: QMI Framework - Qualcomm Messaging Interface
 Version: @VERSION@
 Requires:
 Libs: -L${libdir} -lqcci -lqcsi -lqencdec -lqmi_common
-Cflags: -I${includedir}
+Cflags: -I${includedir}/qmi_framework


### PR DESCRIPTION
Headers install to "$(includedir)/qmi_framework (per pkginclude_HEADERS in Makefile.am), but Cflags only added -I${includedir}," one directory short. Consumers using pkg-config --cflags qmi-framework could not locate headers with a plain #include "qmi_idl_lib.h".