### PR TITLE
ci: Restore toolchain download with working URL, add wget retries

### DIFF
--- a/.github/workflows/build_linux_gnu.yml
+++ b/.github/workflows/build_linux_gnu.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Install Autotools
         run: sudo apt-get install -y automake autoconf libtool
 
-      - name: Download Linaro Toolchain
+      - name: Download Arm GNU Toolchain
         run: |
-          wget -c https://releases.linaro.org/components/toolchain/binaries/latest-7/aarch64-linux-gnu/gcc-linaro-7.5.0-2019.12-i686_aarch64-linux-gnu.tar.xz
-          tar xf gcc-linaro-7.5.0-2019.12-i686_aarch64-linux-gnu.tar.xz
+          wget --tries=3 --waitretry=5 --timeout=30 https://developer.arm.com/-/media/Files/downloads/gnu-a/8.3-2019.03/binrel/gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu.tar.xz
+          tar xf gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu.tar.xz
 
       - name: Install dependencies and kernel headers
         run: |
@@ -38,7 +38,7 @@ jobs:
 
       - name: Download and extract Linux kernel source
         run: |
-          wget https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.10.198.tar.xz
+          wget --tries=3 --waitretry=5 --timeout=30 https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.10.198.tar.xz
           tar -xf linux-5.10.198.tar.xz
           cd linux-5.10.198
           make mrproper
@@ -47,7 +47,7 @@ jobs:
 
       - name: Set Build Environment
         run: |
-          export PATH="$PWD/gcc-linaro-7.5.0-2019.12-i686_aarch64-linux-gnu/bin/:$PATH"
+          export PATH="$PWD/gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu/bin/:$PATH"
           export CC=aarch64-linux-gnu-gcc
           export CXX=aarch64-linux-gnu-g++
           export C_INCLUDE_PATH="$GITHUB_WORKSPACE/linux-headers/include"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,9 +37,14 @@ jobs:
           libncurses-dev flex bison \
           wget xz-utils build-essential bc
 
+    - name: Download Arm GNU Toolchain
+      run: |
+        wget --tries=3 --waitretry=5 --timeout=30 https://developer.arm.com/-/media/Files/downloads/gnu-a/8.3-2019.03/binrel/gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu.tar.xz
+        tar xf gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu.tar.xz
+
     - name: Download and extract Linux kernel source
       run: |
-        wget https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.10.198.tar.xz
+        wget --tries=3 --waitretry=5 --timeout=30 https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.10.198.tar.xz
         tar -xf linux-5.10.198.tar.xz
         cd linux-5.10.198
         make mrproper
@@ -56,7 +61,7 @@ jobs:
       shell: bash
       name: Set Up Build Environment and Compile
       run: |
-        export PATH="$PWD/gcc-linaro-7.5.0-2019.12-i686_aarch64-linux-gnu/bin/:$PATH"
+        export PATH="$PWD/gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu/bin/:$PATH"
         export CC=aarch64-linux-gnu-gcc
         export CXX=aarch64-linux-gnu-g++
         export C_INCLUDE_PATH="$GITHUB_WORKSPACE/linux-headers/include"


### PR DESCRIPTION
releases.linaro.org now permanently redirects to a contact page, so re-point the toolchain download at developer.arm.com's official gcc-arm-8.3-2019.03 aarch64-linux-gnu release, which is verified reachable and matches the existing --host=aarch64-linux-gnu build.

Also add wget retry/timeout flags to both toolchain and kernel source downloads, since the kernel source fetch from cdn.kernel.org separately failed on a transient 503 mid-transfer.